### PR TITLE
Add box-sizing to outer beacon

### DIFF
--- a/lib/styles/react-joyride-compiled.css
+++ b/lib/styles/react-joyride-compiled.css
@@ -25,6 +25,7 @@
     border: 2px solid #f04;
     border-radius: 50%;
     display: block;
+    box-sizing: border-box;
     height: 100%;
     left: 0;
     opacity: 0.9;

--- a/lib/styles/react-joyride.scss
+++ b/lib/styles/react-joyride.scss
@@ -88,6 +88,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
       border: ($joyride-beacon-size / 18) solid $joyride-beacon-color;
       border-radius: 50%;
       display: block;
+      box-sizing: border-box;
       height: 100%;
       left: 0;
       opacity: 0.9;

--- a/src/styles/react-joyride.scss
+++ b/src/styles/react-joyride.scss
@@ -88,6 +88,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
       border: ($joyride-beacon-size / 18) solid $joyride-beacon-color;
       border-radius: 50%;
       display: block;
+      box-sizing: border-box;
       height: 100%;
       left: 0;
       opacity: 0.9;


### PR DESCRIPTION
This fixes https://github.com/gilbarbara/react-joyride/issues/139.

Ref: https://github.com/gilbarbara/react-joyride/pull/145