### PR TITLE
Fix scrolling in Chrome v61+

### DIFF
--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -64,7 +64,8 @@ export const browser = getBrowser();
  * @returns {Element}
  */
 export function getRootEl() {
-  return ['ie', 'firefox'].indexOf(getBrowser()) > -1 ? document.documentElement : document.body;
+  const scrollingElement = document.scrollingElement || document.body;
+  return ['ie', 'firefox'].indexOf(browser) > -1 ? document.documentElement : scrollingElement;
 }
 
 /**


### PR DESCRIPTION
### Description
- [Jira Ticket](https://nutshell.atlassian.net/browse/NUT-8175)

Auto-scrolling in our joyride is broken in recent (v61) versions of Chrome.

This has been fixed in the most recent (`1.11.0`) release of the upstream library ([commit](https://github.com/gilbarbara/react-joyride/commit/053a001606a8c6a6fc6928c6de68bc11f2c6cbb5)). As we're a couple of versions back, and have commits of our own in this fork, I'm not sure how easy the upgrade path would be, so here's a PR against ours. Open to discussion about the best way to do this.